### PR TITLE
Add refresh lockfile workflow

### DIFF
--- a/.github/workflows/refresh-lockfiles.yml
+++ b/.github/workflows/refresh-lockfiles.yml
@@ -78,6 +78,7 @@ jobs:
         run: |
           cp artifacts/artifact/*.lock requirements/ci/nox.lock
           rm -r artifacts
+
       - name: "Generate token"
         uses: tibdex/github-app-token@v1
         id: generate-token

--- a/.github/workflows/refresh-lockfiles.yml
+++ b/.github/workflows/refresh-lockfiles.yml
@@ -1,0 +1,111 @@
+# This workflow periodically creates new environment lock files based on the newest
+# available packages and dependencies.
+#
+# Environment specifications are given as conda environment.yml files found in
+# `requirements/ci/py**.yml`.  These state the packages required, the conda channels
+# that the packages will be pulled from, and any versions of packages that need to be
+# pinned at specific versions.
+#
+# For environments that have changed, a pull request will be made and submitted
+# to the main branch
+
+name: Refresh Lockfiles
+
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+
+jobs:
+
+  get_python_matrix:
+    # Determines which Python versions should be included in the matrix used in
+    # the gen_lockfiles job.
+    if: "github.repository_owner == 'SciTools'"
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.get_py.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: get_py
+        run: echo "::set-output name=matrix::$(ls -1 requirements/ci/py*.yml | xargs -n1 basename | sed 's/....$//' | jq -cnR '[inputs]')"
+
+  gen_lockfiles:
+    # This is a matrix job: it splits to create new lockfiles for each
+    # of the CI test python versions.
+    if: "github.repository_owner == 'SciTools'"
+    runs-on: ubuntu-latest
+    needs: get_python_matrix
+
+    strategy:
+      matrix:
+        python: ${{ fromJSON(needs.get_python_matrix.outputs.matrix) }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: install requirements
+        run: |
+          source $CONDA/bin/activate base
+          conda install -y -c conda-forge conda-libmamba-solver conda-lock
+      - name: generate lockfile
+        env:
+          CONDA_EXPERIMENTAL_SOLVER: libmamba
+        run: |
+          $CONDA/bin/conda-lock lock -k explicit -p linux-64 -f requirements/ci/${{matrix.python}}.yml
+          mv conda-linux-64.lock ${{matrix.python}}-linux-64.lock
+      - name: output lockfile
+        uses: actions/upload-artifact@v3
+        with:
+          path: ${{matrix.python}}-linux-64.lock
+
+  create_pr:
+    # Once the matrix job has completed all the lock files will have been
+    # uploaded as artifacts.
+    # Download the artifacts, add them to the repo, and create a PR.
+    if: "github.repository_owner == 'SciTools'"
+    runs-on: ubuntu-latest
+    needs: gen_lockfiles
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: get artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: artifacts
+
+      - name: Update lock files in repo
+        run: |
+          cp artifacts/artifact/*.lock requirements/ci/nox.lock
+          rm -r artifacts
+      - name: "Generate token"
+        uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.AUTH_APP_ID }}
+          private_key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
+
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@b4d51739f96fca8047ad065eccef63442d8e99f7
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          commit-message: Updated environment lockfiles
+          committer: "Lockfile bot <noreply@github.com>"
+          author: "Lockfile bot <noreply@github.com>"
+          delete-branch: true
+          branch: auto-update-lockfiles
+          title: "[CI Bot] environment lockfiles auto-update"
+          body: |
+            Lockfiles updated to the latest resolvable environment.
+            ### If the CI tasks fail, create a new branch based on this PR and add the required fixes to that branch.
+          labels: |
+            New: Pull Request
+            Bot
+      - name: Check Pull Request
+        if: steps.cpr.outputs.pull-request-number != ''
+        run: |
+          echo "pull-request #${{ steps.cpr.outputs.pull-request-number }}"
+          echo "pull-request URL ${{ steps.cpr.outputs.pull-request-url }}"
+          echo "pull-request operation [${{ steps.cpr.outputs.pull-request-operation }}]"
+          echo "pull-request head SHA ${{ steps.cpr.outputs.pull-request-head-sha }}"     


### PR DESCRIPTION
This adds a simple workflow that refreshes the lockfiles.

This can be used by:
Iris: https://github.com/SciTools/iris/pull/5036
Iris-grib: https://github.com/SciTools/iris-grib/pull/304

This will need to go in first, then we can get the SHA to point the above PRs at when they reference this workflow.