### PR TITLE
Add pin for libarchive

### DIFF
--- a/.github/workflows/refresh-lockfiles.yml
+++ b/.github/workflows/refresh-lockfiles.yml
@@ -45,9 +45,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: install requirements
+        # Pin libarchive to avoid the conda-forge build which uses the
+        # incorrect SONAME scheme (see conda-forge/libarchive-feedstock/issues/69).
         run: |
           source $CONDA/bin/activate base
-          conda install -y -c conda-forge conda-libmamba-solver conda-lock
+          conda install -y -c conda-forge conda-libmamba-solver conda-lock libarchive=3.5.2=h5de8990_0
       - name: generate lockfile
         env:
           CONDA_EXPERIMENTAL_SOLVER: libmamba


### PR DESCRIPTION
The refresh lockfile GHA started failing on Iris this past weekend. The change is that we started getting `libarchive` from `conda-forge` rather than `main` where we previously were getting it.

The problem with the `conda-forge` build is that they use the wrong versioning scheme for their SOs, and this doesn't seem compatible with mamba.

We get the following [error](https://github.com/SciTools/iris/actions/runs/3349298380/jobs/5549161146#step:4:59) with mamba:
```
" ImportError: libarchive.so.18: cannot open shared object file: No such file or directory\n\nTry (re)installing conda-libmamba-solver."
```
so it's looking for `libarchive.so.18`

This is available in the `main` build:
```
$ ls -1 $CONDA_PREFIX/lib/libarchive*
/path/to/env/lib/libarchive.a
/path/to/env/lib/libarchive.so
/path/to/env/lib/libarchive.so.18
```

but not in the `conda-forge` build:
```
$ ls -1 $CONDA_PREFIX/lib/libarchive*
/path/to/env/lib/libarchive.a
/path/to/env/lib/libarchive.so
/path/to/env/lib/libarchive.so.13
/path/to/env/lib/libarchive.so.13.5.2
```
Further details are on this issue: https://github.com/conda-forge/libarchive-feedstock/issues/69

So for now we need to a specific version of libarchive.