### PR TITLE
Use the vanilla mamba install now mamba is at `1.0`.

### DIFF
--- a/.github/workflows/refresh-lockfiles.yml
+++ b/.github/workflows/refresh-lockfiles.yml
@@ -49,10 +49,8 @@ jobs:
         # incorrect SONAME scheme (see conda-forge/libarchive-feedstock/issues/69).
         run: |
           source $CONDA/bin/activate base
-          conda install -y -c conda-forge conda-libmamba-solver conda-lock libarchive=3.5.2=h5de8990_0
+          conda install -y -c conda-forge mamba conda-lock libarchive=3.5.2=h5de8990_0
       - name: generate lockfile
-        env:
-          CONDA_EXPERIMENTAL_SOLVER: libmamba
         run: |
           $CONDA/bin/conda-lock lock -k explicit -p linux-64 -f requirements/ci/${{matrix.python}}.yml
           mv conda-linux-64.lock ${{matrix.python}}-linux-64.lock


### PR DESCRIPTION
I now consider Mamba safe to use given the `1.0` release in late 2022. The implementation suggested here is more conventional / less surprising and that's always good.

I have confirmed in my own uses that Conda lock will default to using Mamba if it is available in the environment.

I believe this closes SciTools/iris#5139 - testing locally I am able to resolve the desired lock files by running `conda-lock lock` in an environment that also contains Mamba.

Not sure how to test that this action works as intended. Have we established any norms on this yet?