### PR TITLE
Install libarchive from Conda defaults channel.

### DIFF
--- a/.github/workflows/refresh-lockfiles.yml
+++ b/.github/workflows/refresh-lockfiles.yml
@@ -45,8 +45,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: install requirements
-        # Pin libarchive to avoid the conda-forge build which uses the
-        # incorrect SONAME scheme (see conda-forge/libarchive-feedstock/issues/69).
         run: |
           source $CONDA/bin/activate base
           # libarchive on conda-forge is faulty: conda-forge/libarchive-feedstock#69

--- a/.github/workflows/refresh-lockfiles.yml
+++ b/.github/workflows/refresh-lockfiles.yml
@@ -49,7 +49,9 @@ jobs:
         # incorrect SONAME scheme (see conda-forge/libarchive-feedstock/issues/69).
         run: |
           source $CONDA/bin/activate base
-          conda install -y -c conda-forge mamba conda-lock libarchive=3.5.2=h5de8990_0
+          # libarchive on conda-forge is faulty: conda-forge/libarchive-feedstock#69
+          conda install -y -c defaults libarchive
+          conda install -y -c conda-forge mamba conda-lock
       - name: generate lockfile
         run: |
           $CONDA/bin/conda-lock lock -k explicit -p linux-64 -f requirements/${{matrix.python}}.yml


### PR DESCRIPTION
Closes #4 

I tested this a couple of months ago and the problem discussed in #3 does not occur if `libarchive` is installed from the default channel instead of conda-forge.