### PR TITLE
patch deprecated set-output GHA command

### DIFF
--- a/.github/workflows/refresh-lockfiles.yml
+++ b/.github/workflows/refresh-lockfiles.yml
@@ -16,9 +16,11 @@ on:
   workflow_dispatch:
   workflow_call:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-
   get_python_matrix:
     # Determines which Python versions should be included in the matrix used in
     # the gen_lockfiles job.
@@ -29,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - id: get_py
-        run: echo "::set-output name=matrix::$(ls -1 requirements/py*.yml | xargs -n1 basename | sed 's/....$//' | jq -cnR '[inputs]')"
+        run: echo "MATRIX=$(ls -1 requirements/py*.yml | xargs -n1 basename | sed 's/....$//' | jq -cnR '[inputs]')" >> ${GITHUB_OUTPUT}
 
   gen_lockfiles:
     # This is a matrix job: it splits to create new lockfiles for each
@@ -40,7 +42,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ${{ fromJSON(needs.get_python_matrix.outputs.matrix) }}
+        python: ${{ fromJSON(needs.get_python_matrix.outputs.MATRIX) }}
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This PR addresses the following GHA deprecation warning:

![image](https://user-images.githubusercontent.com/2051656/227540144-1712c0b8-3d0a-4900-baea-af0203e514f4.png)

For reference, see:
- [python-stratify GHA Annotations warning](https://github.com/SciTools/python-stratify/actions/runs/4510682971) (as above)
- [GitHub Actions: Deprecating save-state and set-output commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
- [Setting an output parameter](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter)

Here is evidence of the changes in this PR working on [bjlittle/workflows](https://github.com/bjlittle/workflows/actions/runs/4511880391). Note that, the `create_pr` task fails as there is no GitHub App configured to provide the necessary `secrets` tokens for the `create_pull-request` GHA.