### PR TITLE
perform auto-version and release on push

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -56,7 +56,7 @@ jobs:
           fi
           git config user.name "GitHub Actions"
           git config user.email "actions@users.noreply.github.com"
-          git commit -am "Automated release for verison \"${WF_VERSION}\""
+          git commit -am "Automated release for version \"${WF_VERSION}\""
           git push  
 
       - name: "perform release"

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -33,19 +33,20 @@ jobs:
           if [ -f "${WF_VERSION_FNAME}" ]
           then
             WF_VERSION=$(cat ${WF_VERSION_FNAME})
+            WF_DATE=$(echo ${WF_VERSION} | cut -d. -f1-2)
+            WF_SERIAL=$(echo ${WF_VERSION} | cut -d. -f3)
+            NOW_DATE=$(date +%Y.%m)
+            NOW_SERIAL=0
+            if [ "${WF_DATE}" == "${NOW_DATE}" ]
+            then
+              NOW_SERIAL=$(expr ${WF_SERIAL} + 1)
+            fi
+            WF_VERSION="${NOW_DATE}.${NOW_SERIAL}"
           else
             WF_VERSION="$(date +%Y.%m).0"
             echo "WF_BOOTSTRAP=1" >> ${GITHUB_ENV}
           fi
-          WF_DATE=$(echo ${WF_VERSION} | cut -d. -f1-2)
-          WF_SERIAL=$(echo ${WF_VERSION} | cut -d. -f3)
-          NOW_DATE=$(date +%Y.%m)
-          NOW_SERIAL=0
-          if [ "${WF_DATE}" == "${NOW_DATE}" ]
-          then
-            NOW_SERIAL=$(expr ${WF_SERIAL} + 1)
-          fi
-          echo "WF_VERSION=${NOW_DATE}.${NOW_SERIAL}" >> ${GITHUB_ENV}
+          echo "WF_VERSION=${WF_VERSION}" >> ${GITHUB_ENV}
 
       - name: "store release version"
         run: |

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -1,0 +1,65 @@
+name: ci-release
+
+on:
+  push:
+    branches:
+      - main
+
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    env:
+      WF_VERSION_FNAME: "version.txt"
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: "calculate release version"
+        run: |
+          git pull
+          if [ -f "${WF_VERSION_FNAME}" ]
+          then
+            WF_VERSION=$(cat ${WF_VERSION_FNAME})
+          else
+            WF_VERSION="$(date +%Y.%m).0"
+            echo "WF_BOOTSTRAP=1" >> ${GITHUB_ENV}
+          fi
+          WF_DATE=$(echo ${WF_VERSION} | cut -d. -f1-2)
+          WF_SERIAL=$(echo ${WF_VERSION} | cut -d. -f3)
+          NOW_DATE=$(date +%Y.%m)
+          NOW_SERIAL=0
+          if [ "${WF_DATE}" == "${NOW_DATE}" ]
+          then
+            NOW_SERIAL=$(expr ${WF_SERIAL} + 1)
+          fi
+          echo "WF_VERSION=${NOW_DATE}.${NOW_SERIAL}" >> ${GITHUB_ENV}
+
+      - name: "store release version"
+        run: |
+          echo ${{ env.WF_VERSION }} > ${WF_VERSION_FNAME}
+          if [ -n "${WF_BOOTSTRAP}" ]
+          then
+            git add ${WF_VERSION_FNAME}
+          fi
+          git config user.name "GitHub Actions"
+          git config user.email "actions@users.noreply.github.com"
+          git commit -am "Automated release for verison \"${WF_VERSION}\""
+          git push  
+
+      - name: "perform release"
+        uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
+        with:
+          tag_name: ${{ env.WF_VERSION }}

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -58,7 +58,7 @@ jobs:
           git config user.name "GitHub Actions"
           git config user.email "actions@users.noreply.github.com"
           git commit -am "Automated release for version \"${WF_VERSION}\""
-          git push  
+          git push
 
       - name: "perform release"
         uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,8 +2,6 @@
 # See https://pre-commit.com/hooks.html for more hooks
 # See https://pre-commit.ci/#configuration
 
-ci:
-  autofix_prs: false
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: "v4.4.0"


### PR DESCRIPTION
This PR introduces auto-versioning and auto-releases on every atomic `push` to the `main` branch.

The version lives in the new VCS `version.txt` root file, and follows the `YYYY.MM.X` format, where:
- `YYYY` is the year of release
- `MM` is the month of release
- `X` is the release counter (offset) within the month

e.g., `2023.03.0` would be the first version for `Mar 2023`, the subsequent release would be `2023.03.1` if that happened within `Mar 2023`, and so on. If the next following release was `Sept 2024` then the release would be `2024.09.0`.

Rather than use `main` or a commit SHA, clients of the workflow can now do so with the specific version e.g.,

```yaml
jobs:
  refresh_lockfiles:
    uses: scitools/workflows/.github/workflows/refresh-lockfiles.yml@2023.03.24
    secrets: inherit
```

Additionally, if a client repo has `dependabot` configured, then they should be notified of the latest available release version auto-magically.

Also, in the event of a bad `workflows` release, client repos can easily pin back to the last good know operational version. Pinning back will also be useful when client repos don't have the resource to maintain compliance with any breaking changes.