### PR TITLE
generate token for ci-release

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -60,7 +60,15 @@ jobs:
           git commit -am "Automated release for version \"${WF_VERSION}\""
           git push
 
+      - name: "Generate token"
+        uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.AUTH_APP_ID }}
+          private_key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
+
       - name: "perform release"
         uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           tag_name: ${{ env.WF_VERSION }}


### PR DESCRIPTION
This PR uses our SciTools GitHub App to generate a token within the `ci-release` GHA to pass to the [softprops/action-gh-release](https://github.com/softprops/action-gh-release) GHA.

Currently the `ci-release` GHA is prevented from pushing the updated `version.txt` file change due to enforced branch protection rules on the `main` branch.

However, the hope here is that the GH App token use along with the following changes to the `main` branch protection rule, will also the `ci-release` GHA workflow to avoid [this current issue](https://github.com/SciTools/workflows/actions/runs/4544583673/jobs/8010810133).

![image](https://user-images.githubusercontent.com/2051656/228507414-b5b39578-1c44-4ab7-8f1c-3de979a3c4a7.png)
