### PR TITLE
restrict ci-release to scitools owner

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   release:
+    if: "github.repository_owner == 'SciTools'"
     runs-on: ubuntu-latest
 
     defaults:


### PR DESCRIPTION
This PR ensures that the `ci-release` GHA is only performed by `SciTools`.