### PR TITLE
use github-push action for ci-release gha

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -58,14 +58,19 @@ jobs:
           git config user.name "GitHub Actions"
           git config user.email "actions@users.noreply.github.com"
           git commit -am "Automated release for version \"${WF_VERSION}\""
-          git push
 
-      - name: "Generate token"
+      - name: "generate token"
         uses: tibdex/github-app-token@v1
         id: generate-token
         with:
           app_id: ${{ secrets.AUTH_APP_ID }}
           private_key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
+
+      - name: "push version change"
+        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6
+        with:
+          github_token: ${{ steps.generate-token.outputs.token }}
+          branch: ${{ github.ref }}
 
       - name: "perform release"
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844


### PR DESCRIPTION
This PR is a follow-up to #16, and uses the [ad-m/github-push-action](https://github.com/ad-m/github-push-action) instead of `git push` to push the updated `version.txt` file change, but using the provided GH App token.