### PR TITLE
backout ci-release changes

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -58,22 +58,9 @@ jobs:
           git config user.name "GitHub Actions"
           git config user.email "actions@users.noreply.github.com"
           git commit -am "Automated release for version \"${WF_VERSION}\""
-
-      - name: "generate token"
-        uses: tibdex/github-app-token@v1
-        id: generate-token
-        with:
-          app_id: ${{ secrets.AUTH_APP_ID }}
-          private_key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
-
-      - name: "push version change"
-        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6
-        with:
-          github_token: ${{ steps.generate-token.outputs.token }}
-          branch: ${{ github.ref }}
+          git push
 
       - name: "perform release"
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
         with:
-          token: ${{ steps.generate-token.outputs.token }}
           tag_name: ${{ env.WF_VERSION }}


### PR DESCRIPTION
This PR backs-out the failed attempts of #19 and #16.

This also involves aborting the `main` branch protection rule to `Require a pull request before merging`. 