### PR TITLE
Add ci-manifest GHA

### DIFF
--- a/.github/workflows/ci-manifest.yml
+++ b/.github/workflows/ci-manifest.yml
@@ -1,0 +1,41 @@
+# Reference:
+#   - https://github.com/actions/checkout
+#   - https://github.com/mgedmin/check-manifest
+
+name: ci-manifest
+
+on:
+  pull_request:
+    branches:
+      - "*"
+
+  push:
+    branches-ignore:
+      - "auto-update-lockfiles"
+      - "dependabot/*"
+      - "pre-commit-ci-update-config"
+
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  manifest:
+    name: "check-manifest"
+
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: "check-manifest"
+        run: |
+          pipx run check-manifest


### PR DESCRIPTION
This PR adds the `ci-manifest` GHA as a reusable workflow that will allow client `scitools` repositories to automate verifying their `MANIFEST.in` with their PyPI source and binary distributions.

This provides confidence that we're not publishing broken packages to PyPI or packages that have missing/extra payload.