### PR TITLE
Enable lockfile refresh on forks via workflow_dispatch

### DIFF
--- a/.github/workflows/refresh-lockfiles.yml
+++ b/.github/workflows/refresh-lockfiles.yml
@@ -24,7 +24,7 @@ jobs:
   get_python_matrix:
     # Determines which Python versions should be included in the matrix used in
     # the gen_lockfiles job.
-    if: "github.repository_owner == 'SciTools'"
+    if: "github.repository_owner == 'SciTools' || github.event_name == 'workflow_dispatch'"
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.get_py.outputs.matrix }}
@@ -36,7 +36,7 @@ jobs:
   gen_lockfiles:
     # This is a matrix job: it splits to create new lockfiles for each
     # of the CI test python versions.
-    if: "github.repository_owner == 'SciTools'"
+    if: "github.repository_owner == 'SciTools' || github.event_name == 'workflow_dispatch'"
     runs-on: ubuntu-latest
     needs: get_python_matrix
 
@@ -65,7 +65,7 @@ jobs:
     # Once the matrix job has completed all the lock files will have been
     # uploaded as artifacts.
     # Download the artifacts, add them to the repo, and create a PR.
-    if: "github.repository_owner == 'SciTools'"
+    if: "github.repository_owner == 'SciTools' || github.event_name == 'workflow_dispatch'"
     runs-on: ubuntu-latest
     needs: gen_lockfiles
 


### PR DESCRIPTION
Iris’s lockfile re-generation script says

>    "Iris' large requirements may require Mamba to successfully solve. If you "
>    "don't want to install Mamba, consider using the workflow_dispatch on "
>    "Iris' GitHub action."

([link](https://github.com/SciTools/iris/blob/87869626e6ff955c7188eb049751b5f18254452b/tools/update_lockfiles.py#L24-L26))

So I tried using the workflow_dispatch for my branch, but [everything was skipped](https://github.com/rcomer/iris/actions/runs/4583114027) ☹️

I believe this change should enable the action to run on forks via workflow_dispatch, but I am far from an expert in GitHub actions.