### PR TITLE
remove concurrency

### DIFF
--- a/.github/workflows/ci-manifest.yml
+++ b/.github/workflows/ci-manifest.yml
@@ -7,10 +7,6 @@ name: ci-manifest
 on:
   workflow_call:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   manifest:
     name: "check-manifest"

--- a/.github/workflows/refresh-lockfiles.yml
+++ b/.github/workflows/refresh-lockfiles.yml
@@ -13,12 +13,7 @@ name: Refresh Lockfiles
 
 
 on:
-  workflow_dispatch:
   workflow_call:
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
   get_python_matrix:


### PR DESCRIPTION
This PR removes the concurrency statement from the `refresh-lockfiles` and `ci-manifest` GHA.

The concurrency should be controlled by the reusable workflow caller instead.