### PR TITLE
use github step summary for locks

### DIFF
--- a/.github/workflows/refresh-lockfiles.yml
+++ b/.github/workflows/refresh-lockfiles.yml
@@ -100,10 +100,14 @@ jobs:
           labels: |
             New: Pull Request
             Bot
+
       - name: Check Pull Request
         if: steps.cpr.outputs.pull-request-number != ''
         run: |
-          echo "pull-request #${{ steps.cpr.outputs.pull-request-number }}"
-          echo "pull-request URL ${{ steps.cpr.outputs.pull-request-url }}"
-          echo "pull-request operation [${{ steps.cpr.outputs.pull-request-operation }}]"
-          echo "pull-request head SHA ${{ steps.cpr.outputs.pull-request-head-sha }}"
+          echo "### :rocket: Pull-Request Summary" >> ${GITHUB_STEP_SUMMARY}
+          echo "" >> ${GITHUB_STEP_SUMMARY}
+          echo "The following lock-files pull-request has been auto-generated:"
+          echo "- **PR** #${{ steps.cpr.outputs.pull-request-number }}" >> ${GITHUB_STEP_SUMMARY}
+          echo "- **URL** ${{ steps.cpr.outputs.pull-request-url }}" >> ${GITHUB_STEP_SUMMARY}
+          echo "- **Operation** [${{ steps.cpr.outputs.pull-request-operation }}]" >> ${GITHUB_STEP_SUMMARY}
+          echo "- **SHA** ${{ steps.cpr.outputs.pull-request-head-sha }}" >> ${GITHUB_STEP_SUMMARY}


### PR DESCRIPTION
This PR adds a GHA job summary, see [here](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary), to give more accessible details to the auto-generated pull-request of a successful `refresh-lockfiles` run.

For an example of the output generated, see [here](https://github.com/bjlittle/geovista-slam/actions/runs/4704824720), which renders a similar GHA job summary.

Adding such a summary should make it easier to refer to the historical pull-request auto-generated by the GHA.

e.g.,
![image](https://user-images.githubusercontent.com/2051656/232482467-b2088d54-0a00-4fb2-aac8-b307ae982173.png)
