### PR TITLE
Automatically label lockfile pull requests for benchmarking

### DIFF
--- a/.github/workflows/refresh-lockfiles.yml
+++ b/.github/workflows/refresh-lockfiles.yml
@@ -100,6 +100,7 @@ jobs:
           labels: |
             New: Pull Request
             Bot
+            benchmark_this
 
       - name: Check Pull Request
         if: steps.cpr.outputs.pull-request-number != ''


### PR DESCRIPTION
See [SciTools/iris `benchmarks/README.md`](https://github.com/SciTools/iris/blob/8361532d141a16ec44ecf65e85162c583c7c6d06/benchmarks/README.md) for more

Note that this feature is currently under repair in [SciTools/iris `FEATURE_benchmarks`](https://github.com/SciTools/iris/tree/FEATURE_benchmarks), but it would be good to be prepared so this doesn't get forgotten about. In the meantime the label does no harm.