### PR TITLE
Update README.rst to mention the CLA

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,10 @@ Common [reusable GitHub workflows](https://docs.github.com/en/actions/using-work
 ## License
 
 `workflows` is distributed under the terms of the [BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html) license.
+
+## CLA
+
+The [**CLA**](https://cla-assistant.io/SciTools/) check will run on pull
+requests, as with the rest of SciTools, but the CLA is NOT part of any
+branch protection rule as this would block the workflow of merging directly
+to `main`.


### PR DESCRIPTION
See SciTools/.github#19

Since this repo relies on commits directly to `main` (to update the version), we have decided to not have a branch protection rule and just rely on human vigilance.