### PR TITLE
Dependabot check weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,11 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every weekday
-      interval: "daily"
+      # Check early in the week - downstream dependabot checks (e.g. Iris) run deliberately later in the week.
+      #  Therefore allowing time for this update to be merged-and-released first.
+      interval: "weekly"
+      day: "monday"
+      time: "01:00"
+      timezone: "Europe/London"
     labels:
       - "🤖 bot"


### PR DESCRIPTION
Closes #64 

I have a series of matching pull requests ready for all the downstream SciTools repos, which will all be set to run dependabot on Thursday instead.

[Configuration options for the dependabot.yml file - GitHub Docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file)