### PR TITLE
Stop using default channel.

### DIFF
--- a/.github/workflows/refresh-lockfiles.yml
+++ b/.github/workflows/refresh-lockfiles.yml
@@ -44,9 +44,7 @@ jobs:
       - name: install requirements
         run: |
           source $CONDA/bin/activate base
-          # libarchive on conda-forge is faulty: conda-forge/libarchive-feedstock#69
-          conda install -y -c defaults libarchive
-          conda install -y -c conda-forge mamba conda-lock
+          conda install -y -c conda-forge --override-channels libarchive mamba conda-lock
       - name: generate lockfile
         run: |
           $CONDA/bin/conda-lock lock -k explicit -p linux-64 -f requirements/${{matrix.python}}.yml


### PR DESCRIPTION
I'm hopeful that this will fix the recent breakages observed with lockfile refresh in both iris-grib and [iris itself](https://github.com/SciTools/iris/issues/6277)

It seems that the exiting version of the command [`conda install -y -c defaults libarchive`](https://github.com/SciTools/workflows/blob/2024.12.5/.github/workflows/refresh-lockfiles.yml#L47-L48) is what is now failing,
and the comment about the conda-forge version being broken is long out of date.
I'm not sure whether the ubuntu-latest platform, or the conda default channel is what changed, but in any case we shouldn't be using defaults channel any more.

FWIW I did test the "single-command-install-from-conda-forge" version [standalone in GHA](https://github.com/pp-mo/gha_trials/blob/a7b9dc6eb867c3ba64dc3da4af916064b154d021/.github/workflows/callable.yml) and that did seem to work. 