### PR TITLE
Mirror bjlittle/geovista#1337 to fix conda-lock

### DIFF
--- a/.github/workflows/refresh-lockfiles.yml
+++ b/.github/workflows/refresh-lockfiles.yml
@@ -44,10 +44,10 @@ jobs:
       - name: install requirements
         run: |
           source $CONDA/bin/activate base
-          conda install -y -c conda-forge --override-channels libarchive mamba conda-lock
+          conda update -n base --all
       - name: generate lockfile
         run: |
-          $CONDA/bin/conda-lock lock -k explicit -p linux-64 -f requirements/${{matrix.python}}.yml
+          pipx run conda-lock -k explicit -p linux-64 -f requirements/${{matrix.python}}.yml
           mv conda-linux-64.lock ${{matrix.python}}-linux-64.lock
       - name: output lockfile
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
See notes on bjlittle/geovista#1337 for more.

A root-cause fix is on its way but not here yet, so this will help in the meantime. Will hopefully also protect us from future similar cases, and aligns our repositories more closely too.

Next I will attempt to prove that this works. As usual with workflows this is a tricky thing to achieve and I hope can move away from this pattern in future.