### PR TITLE
Add `ci-template-check.yml`

### DIFF
--- a/.github/workflows/ci-template-check.yml
+++ b/.github/workflows/ci-template-check.yml
@@ -1,0 +1,43 @@
+# Checks if a PR makes any changes that ought to be shared via templating.
+# See SciTools/.github/templates/ for more info.
+
+name: ci-template-check
+
+on:
+  workflow_call:
+    inputs:
+      pr_number:
+        required: true
+        type: number
+
+jobs:
+  prompt-share:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Checkout SciTools/.github
+        uses: actions/checkout@v4
+        with:
+          repository: trexfeathers/SciTools.github
+          path: SciTools.github
+          ref: demo_templating
+
+      - name: Generate Token
+        id: generate-token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
+        with:
+          app_id: ${{ secrets.AUTH_APP_ID }}
+          private_key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
+
+      - name: Set up Python
+        # _templating_scripting.py only needs builtins to run.
+        uses: actions/setup-python@v5
+
+      - name: Prompt author to update templates
+        id: prompt_author
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: SciTools.github/templates/_templating_scripting.py prompt-share ${{ inputs.pr_number }}


### PR DESCRIPTION
See SciTools/.github#41 for the detailed context. Will need calling workflows on each of our repos.

## Do we still believe in the workflows repository?

I personally have experienced a lot of frustrations of having one workflow that affects all repositories, as it gets in the way of me introducing a new concept (e.g. #28), means mistakes have large impacts (e.g. #88 vs #93), and makes it difficult to test things (e.g #108).

Templating is an alternative way of achieving the same thing, without the above problems. HOWEVER: we have agreed among the core devs that templating needs to be demonstrated to work BEFORE we apply it to **workflows**. In the meantime I felt it was important to embrace our current way of working.

## Dependent PRs

- [ ] Tephi: SciTools/tephi#206
  Plan to merge and test this before raising PRs on all the other repos
- [ ] Iris: TBA
- [ ] Iris-grib: TBA
- [ ] Python-stratify: TBA
- [ ] Iris-esmf-regrid: TBA
- [ ] Cf-units: TBA
- [ ] Nc-time-axis: TBA
- [ ] test-iris-imagehash: TBA
- [ ] workflows itself?: TBA