### PR TITLE
Correct actions/checkout to reference .github repo

### DIFF
--- a/.github/workflows/ci-template-check.yml
+++ b/.github/workflows/ci-template-check.yml
@@ -21,9 +21,8 @@ jobs:
       - name: Checkout SciTools/.github
         uses: actions/checkout@v4
         with:
-          repository: trexfeathers/SciTools.github
+          repository: SciTools/.github
           path: SciTools.github
-          ref: demo_templating
 
       - name: Generate Token
         id: generate-token


### PR DESCRIPTION
Was previously referencing my fork as a test.

I have checked the documentation for [actions/checkout](https://github.com/actions/checkout): omitting the `branch` key means it will checkout the default branch.