### PR TITLE
`zizmor`: follow-up fixes

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          persist-credentials: false
+          persist-credentials: true
 
       - name: "calculate release version"
         run: |

--- a/.github/workflows/ci-template-check.yml
+++ b/.github/workflows/ci-template-check.yml
@@ -38,7 +38,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
         with:
-          app-id: ${{ secrets.AUTH_APP_ID }}
+          client-id: ${{ secrets.AUTH_APP_ID }}
           private-key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write

--- a/.github/workflows/refresh-lockfiles.yml
+++ b/.github/workflows/refresh-lockfiles.yml
@@ -95,7 +95,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
         id: generate-token
         with:
-          app-id: ${{ secrets.AUTH_APP_ID }}
+          client-id: ${{ secrets.AUTH_APP_ID }}
           private-key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write


### PR DESCRIPTION
Migrate from deprecated `app-id` to `client-id`, and persist credentials for subsequent `git push` operation ( :crossed_fingers: )